### PR TITLE
A bug that causes corrupted prefs-file due to simultaneous writes is …

### DIFF
--- a/lib/src/preferences_io.dart
+++ b/lib/src/preferences_io.dart
@@ -84,7 +84,6 @@ class IOPreferences extends Preferences {
 
   @override
   Future<bool> setValue(String key, Object value) async {
-    print("Setting value");
     if (key == null) {
       preferenceCache.clear();
       preferenceCache.addAll(value);

--- a/lib/src/preferences_io.dart
+++ b/lib/src/preferences_io.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -83,6 +84,7 @@ class IOPreferences extends Preferences {
 
   @override
   Future<bool> setValue(String key, Object value) async {
+    print("Setting value");
     if (key == null) {
       preferenceCache.clear();
       preferenceCache.addAll(value);
@@ -92,6 +94,17 @@ class IOPreferences extends Preferences {
       preferenceCache[key] = value;
     }
 
+    _markToSave();
+    return true;
+  }
+
+  Timer lastMarked;
+  _markToSave() {
+    lastMarked?.cancel();
+    lastMarked = Timer(Duration(milliseconds: 20), _makeSave);
+  }
+
+  _makeSave() async {
     if (filePath != null) {
       final file = File(filePath);
       if (isCrypted) {
@@ -100,10 +113,9 @@ class IOPreferences extends Preferences {
       try {
         await file.writeAsString(json.encode(preferenceCache));
       } catch (err) {
-        return false;
+        print(err);
       }
     }
-    return true;
   }
 
   /// Completes with true once the user preferences for the app has been cleared.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: crypted_preferences
 description: Flutter preferences management with crypto capabilities
-version: 0.0.2
+version: 0.0.3
 homepage: https://github.com/jaumard/crypted_preferences
 repository: https://github.com/jaumard/crypted_preferences
 author: jaumard <jimmy.aumard@gmail.com>


### PR DESCRIPTION
…fixed in this pull request

If one uses multiple setValue calls in his/her application, each call causes async writeAsString call. This can lead to the file corruption. At least I found that effect on Linux Desktop platform.
To solve this problem I propose a delayed write: setValue just create a delayd task for writing. It no other setValue-s are called the writing occures while if new setValue comes the delay shifts a little bit to the future.